### PR TITLE
List out answer choices in QA4MRE

### DIFF
--- a/lm_eval/tasks/qa4mre/preprocess_qa4mre.py
+++ b/lm_eval/tasks/qa4mre/preprocess_qa4mre.py
@@ -1,2 +1,6 @@
 def qa4mre_process(doc):
     return int(doc["correct_answer_id"]) - 1
+
+
+def doc_to_target(doc):
+    return doc["answer_options"]["answer_str"][qa4mre_process(doc)]

--- a/lm_eval/tasks/qa4mre/qa4mre_2011.yaml
+++ b/lm_eval/tasks/qa4mre/qa4mre_2011.yaml
@@ -6,8 +6,9 @@ dataset_name: 2011.main.EN
 output_type: multiple_choice
 test_split: train
 template_aliases: "{% set answer_choices = answer_options['answer_str'] %}"
-doc_to_text: "{{document_str.strip()}}\nQuestion: {{question_str}}\nAnswer:"
-doc_to_target: !function preprocess_qa4mre.qa4mre_process
+doc_to_text: "{{document_str.strip()}}\nQuestion: {{question_str}}\nChoices:\n- {{answer_choices|join('\n- ')}}\nAnswer:"
+doc_to_target: !function preprocess_qa4mre.doc_to_target
+gold_alias: !function preprocess_qa4mre.qa4mre_process
 should_decontaminate: true
 doc_to_decontamination_query: "{{document_str.strip()}} + ' ' + {{question_str}}"
 metric_list:

--- a/lm_eval/tasks/qa4mre/qa4mre_2012.yaml
+++ b/lm_eval/tasks/qa4mre/qa4mre_2012.yaml
@@ -6,8 +6,9 @@ dataset_name: 2012.main.EN
 output_type: multiple_choice
 test_split: train
 template_aliases: "{% set answer_choices = answer_options['answer_str'] %}"
-doc_to_text: "{{document_str.strip()}}\nQuestion: {{question_str}}\nAnswer:"
-doc_to_target: !function preprocess_qa4mre.qa4mre_process
+doc_to_text: "{{document_str.strip()}}\nQuestion: {{question_str}}\nChoices:\n- {{answer_choices|join('\n- ')}}\nAnswer:"
+doc_to_target: !function preprocess_qa4mre.doc_to_target
+gold_alias: !function preprocess_qa4mre.qa4mre_process
 should_decontaminate: true
 doc_to_decontamination_query: "{{document_str.strip()}} + ' ' + {{question_str}}"
 metric_list:

--- a/lm_eval/tasks/qa4mre/qa4mre_2013.yaml
+++ b/lm_eval/tasks/qa4mre/qa4mre_2013.yaml
@@ -6,8 +6,9 @@ dataset_name: 2013.main.EN
 output_type: multiple_choice
 test_split: train
 template_aliases: "{% set answer_choices = answer_options['answer_str'] %}"
-doc_to_text: "{{document_str.strip()}}\nQuestion: {{question_str}}\nAnswer:"
-doc_to_target: !function preprocess_qa4mre.qa4mre_process
+doc_to_text: "{{document_str.strip()}}\nQuestion: {{question_str}}\nChoices:\n- {{answer_choices|join('\n- ')}}\nAnswer:"
+doc_to_target: !function preprocess_qa4mre.doc_to_target
+gold_alias: !function preprocess_qa4mre.qa4mre_process
 should_decontaminate: true
 doc_to_decontamination_query: "{{document_str.strip()}} + ' ' + {{question_str}}"
 metric_list:


### PR DESCRIPTION
Some of the answer choices for qa4mre involve predicting `" none of the above"`, which doesn't seem like it makes sense as an answer unless the model "knows" what the other choices are via the choices being in context. This PR fixes the lack of a `gold_alias` (causing bugs for few-shot QA4MRE) and also lists answer choices in context.

with these changes I get
```
hf (pretrained=EleutherAI/pythia-70m), limit: None, num_fewshot: 0, batch_size: 1
|   Task    |Version|Filter| Metric |Value |   |Stderr|
|-----------|-------|------|--------|-----:|---|-----:|
|qa4mre_2011|Yaml   |none  |acc     |0.1917|±  |0.0361|
|           |       |none  |acc_norm|0.3500|±  |0.0437|
|qa4mre_2012|Yaml   |none  |acc     |0.1938|±  |0.0313|
|           |       |none  |acc_norm|0.2062|±  |0.0321|
|qa4mre_2013|Yaml   |none  |acc     |0.2641|±  |0.0262|
|           |       |none  |acc_norm|0.2535|±  |0.0259|
```

What do you think? should we break compatibility to have a better implementation?

cc @lintangsutawika @farzanehnakhaee70 